### PR TITLE
CharacterController & Spike Fixes

### DIFF
--- a/SoTA - PreProd/Assets/Prefabs/Level/Spikes.prefab
+++ b/SoTA - PreProd/Assets/Prefabs/Level/Spikes.prefab
@@ -66,7 +66,7 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 0.7, y: 0.7, z: 0.7}
+  m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1001 &6308826095639453072
 PrefabInstance:

--- a/SoTA - PreProd/Assets/Prefabs/Player.prefab
+++ b/SoTA - PreProd/Assets/Prefabs/Player.prefab
@@ -282,7 +282,7 @@ CharacterController:
   m_Enabled: 1
   serializedVersion: 3
   m_Height: 0.5
-  m_Radius: 0.25
+  m_Radius: 0.05
   m_SlopeLimit: 45
   m_StepOffset: 0.3
   m_SkinWidth: 0.08

--- a/SoTA - PreProd/Assets/Scenes/Development scenes/Karin-TemplateScene.unity
+++ b/SoTA - PreProd/Assets/Scenes/Development scenes/Karin-TemplateScene.unity
@@ -941,6 +941,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Player
       objectReference: {fileID: 0}
+    - target: {fileID: 6219084333740346544, guid: 6e9b40bcc8a6f9c45bc480d10d052b71,
+        type: 3}
+      propertyPath: m_Radius
+      value: 0.05
+      objectReference: {fileID: 0}
     - target: {fileID: 7454719805474036125, guid: 6e9b40bcc8a6f9c45bc480d10d052b71,
         type: 3}
       propertyPath: m_LocalPosition.x


### PR DESCRIPTION
The radius of the character collider was too big which was causing the possibility to walk on edges, it has now been changed from 0.25 to 0.05

Made the collider on spikes 1x1x1 to prevent being able to sneak through gaps, though we still need to make sure we align spikes properly to the tiles