### PR TITLE
Greyscale Fading

### DIFF
--- a/SoTA - PreProd/Assets/Prefabs/Managers/RadialColorManager.prefab
+++ b/SoTA - PreProd/Assets/Prefabs/Managers/RadialColorManager.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8982716727998253804}
   - component: {fileID: 4847982055576299270}
+  - component: {fileID: 3718631363897972872}
   m_Layer: 0
   m_Name: RadialColorManager
   m_TagString: Untagged
@@ -49,3 +50,17 @@ MonoBehaviour:
   effectToggle: 1
   effectRadius: 4
   effectRadiusSmoothing: 0.5
+--- !u!114 &3718631363897972872
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1898940110486902253}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 977b7f3e307a1e045b55c5bccc640dfe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  radialColorRenderFeature: {fileID: 328628964419329858, guid: c40be3174f62c4acf8c1216858c64956,
+    type: 2}

--- a/SoTA - PreProd/Assets/Scenes/Karin's Levels/TutorialLevel1.unity
+++ b/SoTA - PreProd/Assets/Scenes/Karin's Levels/TutorialLevel1.unity
@@ -4115,7 +4115,7 @@ PrefabInstance:
     - target: {fileID: 2517525866248969489, guid: 6e9b40bcc8a6f9c45bc480d10d052b71,
         type: 3}
       propertyPath: m_DefaultActionMap
-      value: d05cc5d9-25a7-4880-bebb-816f8f6c8940
+      value: b2ae7480-def4-4b51-bb03-c84c956357af
       objectReference: {fileID: 0}
     - target: {fileID: 7454719805474036125, guid: 6e9b40bcc8a6f9c45bc480d10d052b71,
         type: 3}

--- a/SoTA - PreProd/Assets/Scripts/ColorShader/RadialColorRenderFeature.cs
+++ b/SoTA - PreProd/Assets/Scripts/ColorShader/RadialColorRenderFeature.cs
@@ -17,6 +17,7 @@ public class RadialColorRenderFeature : ScriptableRendererFeature
         private float effectRadiusSmoothing;
         private float effectToggle;
         private int activeLightCount = 0;
+        private float healthBlackout = 0.0f;
 
         public RadialColorRenderPass(Material material)
         {
@@ -27,6 +28,11 @@ public class RadialColorRenderFeature : ScriptableRendererFeature
         public void SetStarPosition(Vector3 screenPos)
         {
             starPosition = new Vector4(screenPos.x, screenPos.y, 0, 0);
+        }
+
+        public void SetHealthBlackout(float value)
+        {
+            healthBlackout = value;
         }
 
         public void SetLightPositions(List<Vector4> lights)
@@ -75,6 +81,9 @@ public class RadialColorRenderFeature : ScriptableRendererFeature
             CommandBuffer cmd = CommandBufferPool.Get("Radial Color Effect");
 
             RenderTargetIdentifier source = renderingData.cameraData.renderer.cameraColorTargetHandle;
+
+            // Pass the health blackout value to the shader
+            material.SetFloat("_HealthBlackout", healthBlackout);
 
             // Pass star and additional light source positions to shader
             material.SetVector("_StarPosition", starPosition);
@@ -126,6 +135,14 @@ public class RadialColorRenderFeature : ScriptableRendererFeature
         if (pass != null)
         {
             renderer.EnqueuePass(pass);
+        }
+    }
+
+    public void SetHealthBlackout(float value)
+    {
+        if (pass != null)
+        {
+            pass.SetHealthBlackout(value); // Correctly calls SetHealthBlackout of RadialColorRenderPass
         }
     }
 

--- a/SoTA - PreProd/Assets/Scripts/Player/PlayerHealthEffect.cs
+++ b/SoTA - PreProd/Assets/Scripts/Player/PlayerHealthEffect.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering.Universal;
+
+public class PlayerHealthEffect : MonoBehaviour
+{
+    // Assigning this through script was complicated due to Unity protection of the render features...
+    [SerializeField] private RadialColorRenderFeature radialColorRenderFeature;
+    private PlayerHealth playerHealth;
+
+    private void Start()
+    {
+        playerHealth = FindObjectOfType<PlayerHealth>();
+
+        if (radialColorRenderFeature == null)
+        {
+            Debug.LogError("RadialColorRenderFeature is not assigned in the Inspector.");
+        }
+    }
+
+    private void Update()
+    {
+        float health = playerHealth.CurrentHealth; // 1.0 to 0.0
+        float blackAmount = 1.0f - health;         // 0.0 (healthy) to 1.0 (dead/black)
+
+        // Update the radial color effect
+        if (radialColorRenderFeature != null)
+        {
+            radialColorRenderFeature.SetHealthBlackout(blackAmount);
+        }
+    }
+}

--- a/SoTA - PreProd/Assets/Scripts/Player/PlayerHealthEffect.cs.meta
+++ b/SoTA - PreProd/Assets/Scripts/Player/PlayerHealthEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 977b7f3e307a1e045b55c5bccc640dfe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SoTA - PreProd/Assets/Shaders/RadialColorMaskURP.shader
+++ b/SoTA - PreProd/Assets/Shaders/RadialColorMaskURP.shader
@@ -7,6 +7,7 @@ Shader "Unlit/RadialColorMaskURP"
         _EffectRadius ("Effect Radius", Float) = 0.2 // Radius in UV space (0 to 1)
         _EffectRadiusSmoothing ("Effect Radius Smoothing", Float) = 0.02 // Smooth edge area in UV space
         _EnableEffect ("Enable Effect", Float) = 1 // This will allow toggling the shader on and off basically
+        _HealthBlackout ("Health Blackout", Range(0,1)) = 0 // For turning the screen black when away from star
     }
     SubShader
     {
@@ -27,6 +28,7 @@ Shader "Unlit/RadialColorMaskURP"
             float4 _LightPositions[MAX_LIGHT_SOURCE_NUM]; 
             float2 _ScreenResolution;
             float _EnableEffect;
+            float _HealthBlackout;
 
             struct appdata_t
             {
@@ -85,6 +87,7 @@ Shader "Unlit/RadialColorMaskURP"
                 // Convert to greyscale
                 half grayscale = dot(col.rgb, half3(0.1, 0.3, 0.05)); // Intensity of the grey
                 half4 greyCol = half4(grayscale, grayscale, grayscale, 1);
+                greyCol = lerp(greyCol, half4(0,0,0,1), _HealthBlackout);
 
                 return lerp(col, greyCol, mask); // Mask is either 0 (color) or 1 (greyscale)
             }


### PR DESCRIPTION
Made changes to the shader to modify so the greyscale smoothly transitions from greyscale to black depending on player health (blackout effect)

Updated the RadialColorRenderFeature with variables and methods for passing the blackout effect to the shader

Added a PlayerHealthEffect script that applies the fading effect

Added the PlayerHealthEffect script to the RadialColorManger prefab and updated the prefab